### PR TITLE
Fix job manager metrics and proxy defaults

### DIFF
--- a/ghostfetch/__init__.py
+++ b/ghostfetch/__init__.py
@@ -3,7 +3,7 @@ GhostFetch - A stealthy headless browser service for AI agents.
 Bypasses anti-bot protections to fetch content and convert to clean Markdown.
 """
 
-__version__ = "2026.2.6"
+__version__ = "2026.2.9"
 
 from ghostfetch.fetch import fetch, fetch_async, fetch_markdown
 from ghostfetch.client import GhostFetchClient

--- a/ghostfetch/cli.py
+++ b/ghostfetch/cli.py
@@ -154,7 +154,7 @@ Examples:
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     parser.add_argument("--metadata-only", action="store_true", help="Only output metadata")
     parser.add_argument("--quiet", "-q", action="store_true", help="Suppress progress messages")
-    parser.add_argument("--version", "-v", action="version", version="%(prog)s 2026.2.6")
+    parser.add_argument("--version", "-v", action="version", version="%(prog)s 2026.2.9")
     
     args = parser.parse_args()
     

--- a/ghostfetch/mcp_server.py
+++ b/ghostfetch/mcp_server.py
@@ -156,7 +156,7 @@ class MCPServer:
                     },
                     "serverInfo": {
                         "name": "ghostfetch",
-                        "version": "2026.2.6"
+                        "version": "2026.2.9"
                     }
                 }
             
@@ -252,4 +252,3 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
-

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from src.utils.config import settings
 app = FastAPI(
     title="GhostFetch API", 
     description="Stealthy headless browser API for AI agents. Fetches content from hard-to-scrape sites and converts to Markdown.",
-    version="2026.2.6",
+version="2026.2.9",
     docs_url="/docs",
     redoc_url="/redoc"
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghostfetch"
-version = "2026.2.6"
+version = "2026.2.9"
 description = "A stealthy headless browser service for AI agents. Bypasses anti-bot protections to fetch content and convert to clean Markdown."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/core/job_manager.py
+++ b/src/core/job_manager.py
@@ -155,13 +155,13 @@ class JobManager:
                             "no_content",
                             retryable=True,
                         )
-                        
-                        job.result = result
-                        job.status = "completed"
-                        job.error = None
-                        job.error_details = None
-                        JOBS_TOTAL.labels(status="completed").inc()
-                        break
+                    
+                    job.result = result
+                    job.status = "completed"
+                    job.error = None
+                    job.error_details = None
+                    JOBS_TOTAL.labels(status="completed").inc()
+                    break
                     except ScraperError as e:
                         logger.error(f"Scraper error for job {job_id}: {e.message}")
                         job.error = e.message

--- a/src/core/job_manager.py
+++ b/src/core/job_manager.py
@@ -127,66 +127,76 @@ class JobManager:
 
     async def _worker(self):
         ACTIVE_WORKERS.inc()
-        while True:
-            QUEUE_SIZE.set(self.queue.qsize())
-            job_id = await self.queue.get()
-            job = self.get_job(job_id)
-            if not job:
-                self.queue.task_done()
-                continue
+        try:
+            while True:
+                QUEUE_SIZE.set(self.queue.qsize())
+                job_id = await self.queue.get()
+                job = self.get_job(job_id)
+                if not job:
+                    self.queue.task_done()
+                    continue
 
-            job.status = "processing"
-            job.started_at = time.time()
-            self._save_job(job)
-            
-            attempt = 0
-            while attempt <= settings.MAX_RETRIES:
-                try:
-                    from src.core.scraper import ScraperError
-                    logger.info(f"Worker processing job {job_id} for {job.url} (Attempt {attempt+1})")
-                    
+                job.status = "processing"
+                job.started_at = time.time()
+                self._save_job(job)
+                
+                attempt = 0
+                while attempt <= settings.MAX_RETRIES:
+                    try:
+                        from src.core.scraper import ScraperError
+                        logger.info(f"Worker processing job {job_id} for {job.url} (Attempt {attempt+1})")
+                        
                     with JOB_DURATION.time():
                         result = await self.scraper.fetch(job.url, context_id=job.context_id)
-                    
-                    job.result = result
-                    job.status = "completed"
-                    job.error = None
-                    job.error_details = None
-                    JOBS_TOTAL.labels(status="completed").inc()
-                    break
-                except ScraperError as e:
-                    logger.error(f"Scraper error for job {job_id}: {e.message}")
-                    job.error = e.message
-                    job.error_details = {"code": e.error_code, "retryable": e.retryable}
-                    
-                    if e.retryable and attempt < settings.MAX_RETRIES:
-                        attempt += 1
-                        import random
-                        delay = (2 ** attempt) + random.uniform(0, 1)
-                        logger.info(f"Retrying job {job_id} in {delay:.2f}s...")
-                        await asyncio.sleep(delay)
-                    else:
+
+                    if not result or not isinstance(result, dict):
+                        raise ScraperError(
+                            "No content could be fetched from the URL",
+                            "no_content",
+                            retryable=True,
+                        )
+                        
+                        job.result = result
+                        job.status = "completed"
+                        job.error = None
+                        job.error_details = None
+                        JOBS_TOTAL.labels(status="completed").inc()
+                        break
+                    except ScraperError as e:
+                        logger.error(f"Scraper error for job {job_id}: {e.message}")
+                        job.error = e.message
+                        job.error_details = {"code": e.error_code, "retryable": e.retryable}
+                        
+                        if e.retryable and attempt < settings.MAX_RETRIES:
+                            attempt += 1
+                            import random
+                            delay = (2 ** attempt) + random.uniform(0, 1)
+                            logger.info(f"Retrying job {job_id} in {delay:.2f}s...")
+                            await asyncio.sleep(delay)
+                        else:
+                            job.status = "failed"
+                            JOBS_TOTAL.labels(status="failed").inc()
+                            break
+                    except Exception as e:
+                        logger.exception(f"Fatal error for job {job_id}")
+                        job.error = str(e)
+                        job.error_details = {"code": "internal_error", "retryable": False}
                         job.status = "failed"
                         JOBS_TOTAL.labels(status="failed").inc()
                         break
-                except Exception as e:
-                    logger.exception(f"Fatal error for job {job_id}")
-                    job.error = str(e)
-                    job.error_details = {"code": "internal_error", "retryable": False}
-                    job.status = "failed"
-                    JOBS_TOTAL.labels(status="failed").inc()
-                    break
-            
-            job.completed_at = time.time()
-            self._save_job(job)
-            self.queue.task_done()
-            QUEUE_SIZE.set(self.queue.qsize())
-            
-            if job.callback_url:
-                asyncio.create_task(self._send_callback_async(job))
-            
-            if job.github_issue:
-                asyncio.create_task(self._send_github_comment_async(job))
+                
+                job.completed_at = time.time()
+                self._save_job(job)
+                self.queue.task_done()
+                QUEUE_SIZE.set(self.queue.qsize())
+                
+                if job.callback_url:
+                    asyncio.create_task(self._send_callback_async(job))
+                
+                if job.github_issue:
+                    asyncio.create_task(self._send_github_comment_async(job))
+        finally:
+            ACTIVE_WORKERS.dec()
 
     async def _send_callback_async(self, job: Job):
         await asyncio.to_thread(self._send_callback, job)
@@ -214,7 +224,8 @@ class JobManager:
         try:
             repo = settings.GITHUB_REPO
             if job.status == "completed":
-                size_kb = len(job.result.get("markdown", "")) / 1024
+                markdown = job.result.get("markdown", "") if isinstance(job.result, dict) else ""
+                size_kb = len(markdown) / 1024
                 body = f"✅ **Done**: Extracted {size_kb:.1f}KB markdown for {job.url}"
             else:
                 retry_text = "(retryable)" if job.error_details and job.error_details.get("retryable") else "(fatal)"

--- a/src/core/stealth_utils.py
+++ b/src/core/stealth_utils.py
@@ -31,12 +31,12 @@ from urllib.parse import urlparse
 
 class ProxyManager:
     """Manages proxy rotation, health tracking, and latency profiling."""
-    def __init__(self, proxies: List[str], strategy: ProxyStrategy = RoundRobinStrategy()):
+    def __init__(self, proxies: List[str], strategy: Optional[ProxyStrategy] = None):
         self.proxies = [p for p in proxies if self._validate_proxy(p)]
         if len(self.proxies) < len(proxies):
             logger.warning(f"Removed {len(proxies) - len(self.proxies)} invalid proxies from the pool.")
         
-        self.strategy = strategy
+        self.strategy = strategy or RoundRobinStrategy()
         self.bad_proxies = set()
         self.proxy_failures = {} # {proxy_url: count}
         self.proxy_latency = {}  # {proxy_url: [latency_ms, ...]}


### PR DESCRIPTION
## Summary
- ensure worker gauge decrements and treat empty fetch results as failures
- tighten GitHub comment guardrail and avoid shared proxy strategy defaults

## Testing
- not run (not requested)
