### PR TITLE
Fix: Direct URL fetch broken (Issue #39)

### DIFF
--- a/ghostfetch/__init__.py
+++ b/ghostfetch/__init__.py
@@ -3,7 +3,7 @@ GhostFetch - A stealthy headless browser service for AI agents.
 Bypasses anti-bot protections to fetch content and convert to clean Markdown.
 """
 
-__version__ = "2026.2.10"
+__version__ = "2026.3.25"
 
 from ghostfetch.fetch import fetch, fetch_async, fetch_markdown
 from ghostfetch.client import GhostFetchClient

--- a/ghostfetch/cli.py
+++ b/ghostfetch/cli.py
@@ -199,9 +199,9 @@ Examples:
             print("\n❌ Setup failed. Please try manually: playwright install chromium")
             sys.exit(1)
             
-    elif args.command == "fetch" or getattr(args, "url", None):
+    elif args.command == "fetch":
         # Direct fetch mode
-        url = getattr(args, "url", None)
+        url = args.url
         if not url:
             parser.print_help()
             sys.exit(0)

--- a/ghostfetch/cli.py
+++ b/ghostfetch/cli.py
@@ -152,7 +152,7 @@ Examples:
     )
     
     # Global flags (also available on subparsers for flexibility)
-    parser.add_argument("--version", "-v", action="version", version="%(prog)s 2026.2.10")
+    parser.add_argument("--version", "-v", action="version", version="%(prog)s 2026.3.25")
     
     subparsers = parser.add_subparsers(dest="command", help="Commands")
     

--- a/ghostfetch/cli.py
+++ b/ghostfetch/cli.py
@@ -123,6 +123,19 @@ def run_server(host: str = "0.0.0.0", port: int = 8000, reload: bool = False):
 
 def main():
     """Main CLI entry point."""
+    # Pre-process arguments to support ghostfetch <url> directly
+    # If the first positional argument is not a known command, assume it's a URL
+    # and insert the 'fetch' command implicitly.
+    commands = ['serve', 'setup', 'fetch']
+    for i, arg in enumerate(sys.argv[1:], 1):
+        if not arg.startswith('-'):
+            if arg in commands:
+                break
+            # Not a known command, must be a URL or invalid choice
+            # We insert 'fetch' to handle it gracefully
+            sys.argv.insert(i, "fetch")
+            break
+
     parser = argparse.ArgumentParser(
         prog="ghostfetch",
         description="🔍 GhostFetch - Stealthy web fetcher for AI agents",
@@ -138,8 +151,26 @@ Examples:
         """
     )
     
+    # Global flags (also available on subparsers for flexibility)
+    parser.add_argument("--version", "-v", action="version", version="%(prog)s 2026.2.10")
+    
     subparsers = parser.add_subparsers(dest="command", help="Commands")
     
+    # Shared flags for fetch operation
+    fetch_shared = argparse.ArgumentParser(add_help=False)
+    fetch_shared.add_argument("--json", action="store_true", help="Output as JSON")
+    fetch_shared.add_argument("--metadata-only", action="store_true", help="Only output metadata")
+    fetch_shared.add_argument("--quiet", "-q", action="store_true", help="Suppress progress messages")
+
+    # Fetch command
+    fetch_parser = subparsers.add_parser("fetch", help="Fetch a URL (default command)", parents=[fetch_shared])
+    fetch_parser.add_argument("url", help="URL to fetch")
+    
+    # Add shared flags to root too so they work before the command
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--metadata-only", action="store_true", help="Only output metadata")
+    parser.add_argument("--quiet", "-q", action="store_true", help="Suppress progress messages")
+
     # Serve command
     serve_parser = subparsers.add_parser("serve", help="Start the API server")
     serve_parser.add_argument("--host", default="0.0.0.0", help="Host to bind to (default: 0.0.0.0)")
@@ -148,13 +179,6 @@ Examples:
     
     # Setup command
     setup_parser = subparsers.add_parser("setup", help="Install required browser dependencies")
-    
-    # URL argument (for direct fetch)
-    parser.add_argument("url", nargs="?", help="URL to fetch")
-    parser.add_argument("--json", action="store_true", help="Output as JSON")
-    parser.add_argument("--metadata-only", action="store_true", help="Only output metadata")
-    parser.add_argument("--quiet", "-q", action="store_true", help="Suppress progress messages")
-    parser.add_argument("--version", "-v", action="version", version="%(prog)s 2026.2.10")
     
     args = parser.parse_args()
     
@@ -175,10 +199,15 @@ Examples:
             print("\n❌ Setup failed. Please try manually: playwright install chromium")
             sys.exit(1)
             
-    elif args.url:
+    elif args.command == "fetch" or getattr(args, "url", None):
         # Direct fetch mode
+        url = getattr(args, "url", None)
+        if not url:
+            parser.print_help()
+            sys.exit(0)
+            
         if not args.quiet:
-            print(f"🔍 Fetching {args.url}...", file=sys.stderr)
+            print(f"🔍 Fetching {url}...", file=sys.stderr)
         
         # Auto-install browsers if needed (silent for non-interactive use)
         if not ensure_browsers_installed(quiet=args.quiet):
@@ -187,7 +216,7 @@ Examples:
             sys.exit(1)
         
         output_format = "json" if args.json else "markdown"
-        run_fetch(args.url, output_format=output_format, metadata_only=args.metadata_only)
+        run_fetch(url, output_format=output_format, metadata_only=args.metadata_only)
         
     else:
         parser.print_help()

--- a/ghostfetch/mcp_server.py
+++ b/ghostfetch/mcp_server.py
@@ -156,7 +156,7 @@ class MCPServer:
                     },
                     "serverInfo": {
                         "name": "ghostfetch",
-                        "version": "2026.2.10"
+                        "version": "2026.3.25"
                     }
                 }
             

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from src.utils.config import settings
 app = FastAPI(
     title="GhostFetch API", 
     description="Stealthy headless browser API for AI agents. Fetches content from hard-to-scrape sites and converts to Markdown.",
-    version="2026.2.10",
+    version="2026.3.25",
     docs_url="/docs",
     redoc_url="/redoc"
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghostfetch"
-version = "2026.2.10"
+version = "2026.3.25"
 description = "A stealthy headless browser service for AI agents. Bypasses anti-bot protections to fetch content and convert to clean Markdown."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
This PR fixes the issue where `ghostfetch <url>` fails with an argument parsing error when subparsers are present.

### Changes:
- Added logic to implicitly insert `fetch` command if the first positional argument is a URL.
- Restructured `argparse` to include a `fetch` subparser.
- Moved URL-related flags to the `fetch` subparser while keeping them on the root for backward compatibility.

Fixes #39
